### PR TITLE
quick links need to be higher as per iphone 12 Pro

### DIFF
--- a/src/css/About.css
+++ b/src/css/About.css
@@ -54,55 +54,6 @@ div.aboutSection .aboutText p {
   color: white;
 }
 
-@media screen and (max-width: 900px) {
-  div.homeContainer div.aboutSection > div.heroContent {
-    display: flex;
-    height: 50vh;
-    width: 50%;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  div.aboutSection .imageContainer {
-    display: flex;
-    width: 15em;
-    justify-content: center;
-  }
-  div.aboutSection .imageContainer img {
-    display: block;
-    width: 100%;
-    height: auto;
-  }
-
-  div.aboutSection .aboutText {
-    width: 15em;
-  }
-
-  div.aboutSection .aboutText h3 {
-    font-size: x-large;
-    white-space: nowrap;
-    margin-top: 2em;
-    margin-bottom: 1em;
-    animation:
-      typing 3s steps(15, end),
-      blink-caret 0.5s step-end infinite;
-  }
-
-  div.aboutSection .aboutText p {
-    font-size: medium;
-    align-self: center;
-  }
-
-  div.homeContainer .section .scroll {
-    top: 8%;
-  }
-
-  div.homeContainer .quickLinks {
-    left: 80%;
-  }
-}
-
 /* The typing effect */
 @keyframes typing {
   from {
@@ -167,5 +118,50 @@ div.homeContainer .section .scroll {
   }
   40% {
     transform: translate(0);
+  }
+}
+
+@media screen and (max-width: 900px) {
+  div.homeContainer div.aboutSection > div.heroContent {
+    display: flex;
+    height: 50vh;
+    width: 50%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  div.aboutSection .imageContainer {
+    display: flex;
+    width: 15em;
+    justify-content: center;
+  }
+  div.aboutSection .imageContainer img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  div.aboutSection .aboutText {
+    width: 15em;
+  }
+
+  div.aboutSection .aboutText h3 {
+    font-size: x-large;
+    white-space: nowrap;
+    margin-top: 2em;
+    margin-bottom: 1em;
+    animation:
+      typing 3s steps(15, end),
+      blink-caret 0.5s step-end infinite;
+  }
+
+  div.aboutSection .aboutText p {
+    font-size: medium;
+    align-self: center;
+  }
+
+  div.homeContainer .section .scroll {
+    display: none;
   }
 }

--- a/src/css/Home.css
+++ b/src/css/Home.css
@@ -295,4 +295,9 @@ div.section .sectionContainer .imageContainer .imageTitle:hover {
     column-count: 2 !important;
     column-gap: 0.5em !important;
   }
+
+  div.homeContainer .quickLinks {
+    left: 80%;
+    top: 55%;
+  }
 }


### PR DESCRIPTION
- The navbar moved to the bottom is obstructing the quicklinks buttons on safari and chrome in iPhone. Pushing it further up